### PR TITLE
Update certificate validation code to fix breaking Terraform 3.0 changes

### DIFF
--- a/terraform/certificate.tf
+++ b/terraform/certificate.tf
@@ -11,10 +11,10 @@ resource "aws_acm_certificate" "webapp" {
 }
 
 resource "aws_route53_record" "webapp_cert_validation" {
-  name    = aws_acm_certificate.webapp.domain_validation_options[0].resource_record_name
-  type    = aws_acm_certificate.webapp.domain_validation_options[0].resource_record_type
+  name    = tolist(aws_acm_certificate.webapp.domain_validation_options)[0].resource_record_name
+  type    = tolist(aws_acm_certificate.webapp.domain_validation_options)[0].resource_record_type
   zone_id = data.aws_route53_zone.zone.id
-  records = [aws_acm_certificate.webapp.domain_validation_options[0].resource_record_value]
+  records = [tolist(aws_acm_certificate.webapp.domain_validation_options)[0].resource_record_value]
   ttl     = 60
 }
 
@@ -33,10 +33,10 @@ resource "aws_acm_certificate" "api" {
 }
 
 resource "aws_route53_record" "api_cert_validation" {
-  name    = aws_acm_certificate.api.domain_validation_options[0].resource_record_name
-  type    = aws_acm_certificate.api.domain_validation_options[0].resource_record_type
+  name    = tolist(aws_acm_certificate.api.domain_validation_options)[0].resource_record_name
+  type    = tolist(aws_acm_certificate.api.domain_validation_options)[0].resource_record_type
   zone_id = data.aws_route53_zone.zone.id
-  records = [aws_acm_certificate.api.domain_validation_options[0].resource_record_value]
+  records = [tolist(aws_acm_certificate.api.domain_validation_options)[0].resource_record_value]
   ttl     = 60
 }
 


### PR DESCRIPTION
Additional information here: https://stackoverflow.com/questions/63235321/aws-acm-certificate-seems-to-have-changed-its-state-output-possibly-due-to-a-pro

You can no longer reference domain_validation_options as a list, as it's now a set. We can cast the resource as a list to overcome this issue, and allow builds on Terraform 3.0.